### PR TITLE
(fix) Make readme example usage use register()

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,18 @@ Your classes can declare helper functions:
 
 namespace Dxw\MyTheme;
 
-class MyClass
+class MyClass implements \Dxw\Iguana\Registerable
 {
+    private $helpers;
+
     public function __construct(\Dxw\Iguana\Theme\Helpers $helpers)
     {
-        $helpers->registerFunction('myFunc', [$this, 'myFunc']);
+        $this->helpers = $helpers;        
+    }
+
+    public function register()
+    {
+        $this->helpers->registerFunction('myFunc', [$this, 'myFunc']);
     }
 
     public function myFunc($a)


### PR DESCRIPTION
Previously, we were suggesting that helperfunctions be registered in a
class's `__construct()` method. This means the calls to
`helpers->registerFunction()` cannot be fully tested.

Registering the helper functions in the `register()` method instead
makes any helper classes more testable, and is more consistent with the way we
implement other iguana-based classes.