### PR TITLE
Fix/layout apply returns string

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         php-versions: ['7.4','8.1','8.2']
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -17,7 +17,7 @@ jobs:
       - name: Get Composer Cache Directory
         id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
-      - uses: actions/cache@v2
+      - uses: actions/cache@v5
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -4,7 +4,7 @@ on:
 
 jobs:
   lint-and-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         php-versions: ['7.4','8.1','8.2']

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [v1.2.0] - 2026-03-11
 ### Changed
 - Bump version of wp_mock
 - Layout::apply() returns a string which is expected by code in WP Core 6.9.2 although removed in 6.9.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Changed
+- Bump version of wp_mock
+
 ## [v1.1.0] - 2023-08-14
 ### Added
 - Support for PHP 8.1 and up

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - Bump version of wp_mock
+- Layout::apply() returns a string which is expected by code in WP Core 6.9.2 although removed in 6.9.3
 
 ## [v1.1.0] - 2023-08-14
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "require-dev": {
         "phpunit/phpunit": "^9.0",
         "mikey179/vfsstream": "^1.6",
-        "10up/wp_mock": "^0.4.2",
+        "10up/wp_mock": "^1.1.0",
         "dxw/php-cs-fixer-config": "^2.1"
     },
     "autoload": {

--- a/src/Layout.php
+++ b/src/Layout.php
@@ -42,6 +42,6 @@ class Layout
 			self::$base = false;
 		}
 
-		return new self();
+		return strval(new self());
 	}
 }

--- a/tests/layout_test.php
+++ b/tests/layout_test.php
@@ -42,7 +42,7 @@ class Layout_Test extends \PHPUnit\Framework\TestCase
 		->with(['layouts/main.php'])
 		->reply(['layouts/my-layout.php']);
 
-		\WP_Mock::wpFunction('locate_template', [
+		\WP_Mock::userFunction('locate_template', [
 			'args' => [['layouts/my-layout.php']],
 			'return' => 'correct output',
 		]);

--- a/tests/layout_test.php
+++ b/tests/layout_test.php
@@ -17,9 +17,13 @@ class Layout_Test extends \PHPUnit\Framework\TestCase
 
 	public function testApply()
 	{
-		$this->assertInstanceOf(
-			\Dxw\Iguana\Theme\Layout::class,
-			\Dxw\Iguana\Theme\Layout::apply('x/y/z.php')
+		\WP_Mock::userFunction('locate_template', [
+			'args' => [[0 => 'layouts/main-z.php', 1 => 'layouts/main.php']],
+			'return' => 'correct output',
+		]);
+
+		$this->assertTrue(
+			is_string(\Dxw\Iguana\Theme\Layout::apply('x/y/z.php'))
 		);
 
 		$this->assertEquals(


### PR DESCRIPTION
# ⚠️ DO NOT MERGE WITHOUT TALKING TO THE TLs

Since WordPress Core 6.9.3 was released this is no longer necessary, but I've kept the PR open for discussion in case we want to merge it defensively.

## Testing

1. Start up any local environment for a site repo that uses `iguana-theme`, these instructions are based on NAO
1. Visit http://localhost/wp-login.php and log in as `admin`
1. Visit http://localhost/wp-admin/site-health.php?tab=debug and checm you are running WordPress Core 6.9.2. If not, run `./script/console` and `wp core install 6.9.2 --force` in the terminal. ⚠️ note that _only_ that version of Core will exhibit this bug, not earlier or later versions.
1. Visit http://localhost and ensure you see a blank page (i.e. no template has loaded)
1. Apply this patch to the `app/load.php` file (or similar) in the theme that you are running so that you can edit files in `vendor/` and hotload the changed file, rather than the `vendor.phar`:

```diff
diff --git i/wp-content/themes/nao-theme/app/load.php w/wp-content/themes/nao-theme/app/load.php
index 57778e1..2e71f28 100644
--- i/wp-content/themes/nao-theme/app/load.php
+++ w/wp-content/themes/nao-theme/app/load.php
@@ -1,5 +1,5 @@
 <?php

-require __DIR__.'/../vendor.phar';
+require __DIR__.'/../vendor/autoload.php';

 return \Dxw\Iguana\Init::init(__DIR__, 'Dxw\\NaoTheme');
```

6. Edit the file `vendor/dxw/iguana-theme/src/Layout.php` relative to the theme root and make the following change to the `apply()` function:

```diff
index c47b9e2..09387bf 100644
--- i/src/Layout.php
+++ w/src/Layout.php
@@ -42,6 +42,6 @@ class Layout
                        self::$base = false;
                }

-               return new self();
+               return strval(new self());
        }
 }
```

7. Reload http://localhost and check you see a meaninful page with a loaded template. Click around and confirm that templates are loaded around the site.
